### PR TITLE
Multiple fixes: model.container_nodes, coerce inbound_layers to list, and coerce output_shape lists to first shape

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # keras2tikz
 Generate (hopefully) readable tikz code for DNN layer diagrams.
 
+Tested on keras 2.3.1.
+
 ## Why?
 
 Keras has a `summary` and a [builtin graphviz export](https://github.com/fchollet/keras/blob/master/keras/utils/vis_utils.py). Both show the input and output shapes of all layers. However, many papers show the layer parameters, so I've added some common parameters like hidden units (Dense + Recurrent), Kernel size and number of filter (Convolutional), Pooling Dimensions... to the output graph...

--- a/model_to_tex.py
+++ b/model_to_tex.py
@@ -90,7 +90,12 @@ def model_to_dot(model,
                 for inbound_layer in inbound_layers:
                     inbound_layer_id = str(id(inbound_layer))
                     layer_id = str(id(layer))
-                    label = str(inbound_layer.output_shape[1:])
+                    output_shape = inbound_layer.output_shape
+                    if isinstance(output_shape, list):
+                        if len(output_shape) > 1:
+                            raise Exception("More than one output_shape found")
+                        output_shape = output_shape[0]
+                    label = str(output_shape[1:])
                     edge = pydot.Edge(inbound_layer_id, layer_id, label=label)
                     dot.add_edge(edge)
 

--- a/model_to_tex.py
+++ b/model_to_tex.py
@@ -83,7 +83,7 @@ def model_to_dot(model,
         layer_id = str(id(layer))
         for i, node in enumerate(layer.inbound_nodes):
             node_key = layer.name + '_ib-' + str(i)
-            if node_key in model.container_nodes:
+            if node_key in model._network_nodes:
                 for inbound_layer in node.inbound_layers:
                     inbound_layer_id = str(id(inbound_layer))
                     layer_id = str(id(layer))

--- a/model_to_tex.py
+++ b/model_to_tex.py
@@ -84,7 +84,10 @@ def model_to_dot(model,
         for i, node in enumerate(layer.inbound_nodes):
             node_key = layer.name + '_ib-' + str(i)
             if node_key in model._network_nodes:
-                for inbound_layer in node.inbound_layers:
+                inbound_layers = node.inbound_layers
+                if not isinstance(inbound_layers, list):
+                    inbound_layers = [inbound_layers]
+                for inbound_layer in inbound_layers:
                     inbound_layer_id = str(id(inbound_layer))
                     layer_id = str(id(layer))
                     label = str(inbound_layer.output_shape[1:])


### PR DESCRIPTION
Three commits. Descriptions for each:

- `model.container_nodes` doesn't exist anymore, so I switched it to `model._network_nodes` as suggested in https://github.com/tensorflow/tensorflow/issues/14542
 - In some cases, `node.inbound_layers` is a `Layer` rather than a `list`. For those cases, coerce `inbound_layers` to a list.
 - In some cases, `layer.output_shape` is a list of shapes. In those cases, take the first and only element of that list. If there is more than one element, throw an exception.